### PR TITLE
feat: add option to set resolved country header

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,11 @@ http:
           databaseAutoUpdateToken: ""                # IP2Location download token (if using premium)
           databaseAutoUpdateCode: "DB1"              # Database product code to download (if using premium)
 
+          #-------------------------------
+          # Response header settings
+          #-------------------------------  
+          countryHeader: "X-IPCountry"  # Optional header to store the country code in
+
 ```
 
 ### 🔄 Processing Order

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - "--log.level=DEBUG"
       - "--accesslog"
       - "--accesslog.filepath=/var/log/traefik/access.log"
+      - "--accesslog.format=json"
       - "--api.insecure=true"
       - "--providers.docker=true"
       - "--providers.docker.exposedbydefault=false"
@@ -93,6 +94,28 @@ services:
       - "traefik.http.middlewares.geoblock-logtest.plugin.geoblock.blockedCountries=US,CN,RU"
       - "traefik.http.middlewares.geoblock-logtest.plugin.geoblock.allowedCountries=DE,FR,GB"
       - "traefik.http.middlewares.geoblock-logtest.plugin.geoblock.defaultAllow=false"
+
+  whoami-countryHeaderTest:
+    image: traefik/whoami
+    container_name: "simple-service-countryHeaderTest"
+    restart: unless-stopped
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.router-countryHeaderTest.rule=PathPrefix(`/countryHeaderTest`)"
+      - "traefik.http.routers.router-countryHeaderTest.entrypoints=web"
+      - "traefik.http.routers.router-countryHeaderTest.middlewares=geoblock-countryHeaderTest@docker"
+      - "traefik.http.services.service-countryHeaderTest.loadbalancer.server.port=80"
+      - "traefik.http.middlewares.geoblock-countryHeaderTest.plugin.geoblock.enabled=true"
+      - "traefik.http.middlewares.geoblock-countryHeaderTest.plugin.geoblock.logLevel=DEBUG"
+      - "traefik.http.middlewares.geoblock-countryHeaderTest.plugin.geoblock.logPath="
+      - "traefik.http.middlewares.geoblock-countryHeaderTest.plugin.geoblock.logFormat=JSON"
+      - "traefik.http.middlewares.geoblock-countryHeaderTest.plugin.geoblock.databaseFilePath=/plugins-local/src/github.com/david-garcia-garcia/traefik-geoblock/IP2LOCATION-LITE-DB1.IPV6.BIN"
+      - "traefik.http.middlewares.geoblock-countryHeaderTest.plugin.geoblock.banHtmlFilePath=/plugins-local/src/github.com/david-garcia-garcia/traefik-geoblock/geoblockban.html"
+      - "traefik.http.middlewares.geoblock-countryHeaderTest.plugin.geoblock.allowPrivate=true"
+      - "traefik.http.middlewares.geoblock-countryHeaderTest.plugin.geoblock.blockedCountries=US,CN,RU"
+      - "traefik.http.middlewares.geoblock-countryHeaderTest.plugin.geoblock.allowedCountries=DE,FR,GB"
+      - "traefik.http.middlewares.geoblock-countryHeaderTest.plugin.geoblock.defaultAllow=false"
+      - "traefik.http.middlewares.geoblock-logtest.plugin.geoblock.countryHeader=X-IPCountry"
 
 volumes:
   logs-local:

--- a/plugin.go
+++ b/plugin.go
@@ -43,6 +43,7 @@ type Config struct {
 	// Response settings
 	DisallowedStatusCode int    // HTTP status code for blocked requests
 	BanHtmlFilePath      string // Custom HTML template for blocked requests
+	CountryHeader        string // Header to write the country code to
 
 	// Logging configuration
 	LogLevel          string // Log level: "debug", "info", "warn", "error"
@@ -76,6 +77,7 @@ func CreateConfig() *Config {
 		IPHeaders:              []string{"x-forwarded-for", "x-real-ip"}, // Default IP headers
 		DatabaseAutoUpdateCode: "DB1",                                    // Default database code
 		LogBannedRequests:      true,                                     // Default to logging blocked requests
+		CountryHeader:      	"",                                       // Default to empty thus not setting the header
 	}
 }
 
@@ -99,6 +101,8 @@ type Plugin struct {
 	bypassHeaders        map[string]string
 	ipHeaders            []string // List of headers to check for client IP addresses
 	logBannedRequests    bool
+	countryHeader        string
+
 }
 
 func createBootstrapLogger(name string) *slog.Logger {
@@ -404,6 +408,7 @@ func New(ctx context.Context, next http.Handler, cfg *Config, name string) (http
 		ipHeaders:            cfg.IPHeaders,
 		logger:               logger,
 		logBannedRequests:    cfg.LogBannedRequests,
+		countryHeader:    	  cfg.CountryHeader,
 	}
 
 	return plugin, nil
@@ -436,6 +441,10 @@ func (p Plugin) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	for _, ip := range remoteIPs {
 		allowed, country, phase, err := p.CheckAllowed(ip)
+
+		if p.countryHeader != "" && country != "" && country != PrivateIpCountryAlias {
+			req.Header.Set(p.countryHeader, country)
+		}
 		if err != nil {
 			var ipChain string = ""
 			if len(remoteIPs) > 1 {

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -507,6 +507,71 @@ func TestPlugin_ServeHTTP(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("Set Country Header", func(t *testing.T) {
+		countryHeader := "X-Country"
+		cfg := &Config{
+			Enabled:              true,
+			DatabaseFilePath:     dbFilePath,
+			AllowedCountries:     []string{"AU"},
+			DisallowedStatusCode: http.StatusForbidden,
+			CountryHeader:        countryHeader,
+		}
+
+		tests := []struct {
+			name                  string
+			ip                    string
+			expectedCode          int
+			expectedCountryHeader string
+			description           string
+		}{
+			{
+				name: "Request from allowed country",
+				ip: "1.1.1.1",
+				expectedCode: http.StatusTeapot,
+				expectedCountryHeader: "AU",
+				description:  "should set country header if request is allowed",
+			},
+			{
+				name: "Request from disallowed country",
+				ip: "8.8.8.8",
+				expectedCountryHeader: "US",
+				expectedCode: http.StatusForbidden,
+				description:  "should set country header if request is denied",
+			},
+			{
+				name: "Request from private IP",
+				ip: "192.168.178.66",
+				expectedCountryHeader: "",
+				expectedCode: http.StatusForbidden,
+				description:  "should not set country header if request has private IP",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				plugin, err := New(context.TODO(), &noopHandler{}, cfg, pluginName)
+				if err != nil {
+					t.Fatalf("expected no error, but got: %v", err)
+				}
+
+				req := httptest.NewRequest(http.MethodGet, "/foobar", nil)
+				req.Header.Set("X-Real-IP", tt.ip)
+
+				rr := httptest.NewRecorder()
+				plugin.ServeHTTP(rr, req)
+
+				if rr.Code != tt.expectedCode {
+					t.Errorf("%s: expected status code %d, but got: %d",
+						tt.description, tt.expectedCode, rr.Code)
+				}
+				header := req.Header.Get(countryHeader)
+				if header != tt.expectedCountryHeader {
+					t.Errorf("expected header %s with value %s, but got: %s", countryHeader, tt.expectedCountryHeader, header)
+				}
+			})
+		}
+	})
 }
 
 func testRequest(t *testing.T, testName string, cfg *Config, ip string, expectedStatus int) {

--- a/scripts/integration-tests.Tests.ps1
+++ b/scripts/integration-tests.Tests.ps1
@@ -306,6 +306,114 @@ Describe "Traefik Geoblock Plugin Integration Tests" {
             $timeDiff = [DateTime]::UtcNow - $timestamp.ToUniversalTime()
             $timeDiff.TotalMinutes | Should -BeLessThan 5
         }
+        
+        It "Should add countryHeader to allowed requests" {
+            # Make an allowed request to the countryHeaderTest endpoint
+            $headers = @{ "X-Real-IP" = $script:TestIPs.German_IP }
+            $result = Invoke-TestRequest -Uri "$script:BaseUrl/countryHeaderTest" -Headers $headers
+            $result.StatusCode | Should -Be 200
+            
+            # Wait a moment for any potential log to be written
+            Start-Sleep -Seconds 2
+            
+            # Read the access.log file from the traefik container
+            $accessLogContent = cat /var/log/traefik/access.log 2>$null
+            if ($LASTEXITCODE -ne 0) {
+                throw "Failed to read traefik access log"
+            }
+            
+            # Parse the log lines and check for any entries related to the German IP
+            $logLines = $accessLogContent -split "`n" | Where-Object { $_.Trim() -ne "" }
+            
+            # Validate that ALL log lines are properly formatted JSON (no malformed lines should exist)
+            $allLogEntries = @()
+            foreach ($line in $logLines) {
+                try {
+                    $logEntry = $line | ConvertFrom-Json
+                    $allLogEntries += $logEntry
+                } catch {
+                    throw "Malformed JSON line found in log file: '$line'."
+                }
+            }
+            
+            # Look for log entries where the X-IPCountry header for Germany is added to the request
+            $countryHeaderLogFound = ($allLogEntries | Where-Object { $_.'request_X-Ipcountry' -eq "DE" }).Count -gt 0
+            
+            # Verify that the country header was added to the request
+            $countryHeaderLogFound | Should -Be $true
+        }
+
+        It "Should add countryHeader to blocked requests" {
+            # Make an allowed request to the countryHeaderTest endpoint
+            $headers = @{ "X-Real-IP" = $script:TestIPs.US_Google_DNS }
+            $result = Invoke-TestRequest -Uri "$script:BaseUrl/countryHeaderTest" -Headers $headers
+            $result.StatusCode | Should -Be 403
+            
+            # Wait a moment for any potential log to be written
+            Start-Sleep -Seconds 2
+            
+            # Read the access.log file from the traefik container
+            $accessLogContent = cat /var/log/traefik/access.log 2>$null
+            if ($LASTEXITCODE -ne 0) {
+                throw "Failed to read traefik access log"
+            }
+            
+            # Parse the log lines and check for any entries related to the German IP
+            $logLines = $accessLogContent -split "`n" | Where-Object { $_.Trim() -ne "" }
+            
+            # Validate that ALL log lines are properly formatted JSON (no malformed lines should exist)
+            $allLogEntries = @()
+            foreach ($line in $logLines) {
+                try {
+                    $logEntry = $line | ConvertFrom-Json
+                    $allLogEntries += $logEntry
+                } catch {
+                    throw "Malformed JSON line found in log file: '$line'."
+                }
+            }
+            
+            # Look for log entries where the X-IPCountry header for US is added to the request
+            $countryHeaderLogFound = ($allLogEntries | Where-Object { $_.'request_X-Ipcountry' -eq "US" }).Count -gt 0
+            
+            # Verify that the country header was added to the request
+            $countryHeaderLogFound | Should -Be $true
+        }
+
+        It "Should not add countryHeader to local requests" {
+            # Make an allowed request to the countryHeaderTest endpoint
+            $headers = @{ "X-Real-IP" = $script:TestIPs.Private_IP }
+            $result = Invoke-TestRequest -Uri "$script:BaseUrl/countryHeaderTest" -Headers $headers
+            $result.StatusCode | Should -Be 200
+            
+            # Wait a moment for any potential log to be written
+            Start-Sleep -Seconds 2
+            
+            # Read the access.log file from the traefik container
+            $accessLogContent = cat /var/log/traefik/access.log 2>$null
+            if ($LASTEXITCODE -ne 0) {
+                throw "Failed to read traefik access log"
+            }
+            
+            # Parse the log lines and check for any entries related to the German IP
+            $logLines = $accessLogContent -split "`n" | Where-Object { $_.Trim() -ne "" }
+            
+            # Validate that ALL log lines are properly formatted JSON (no malformed lines should exist)
+            $allLogEntries = @()
+            foreach ($line in $logLines) {
+                try {
+                    $logEntry = $line | ConvertFrom-Json
+                    $allLogEntries += $logEntry
+                } catch {
+                    throw "Malformed JSON line found in log file: '$line'."
+                }
+            }
+            
+            # Count the log entries with a country header (should be none)
+            $countryHeaderLogFound = ($allLogEntries | Where-Object { -not $_.PSObject.Properties.Match('request_X-Ipcountry') }).Count -gt 0
+            
+            # Verify that the country header was NOT added to the request
+            $countryHeaderLogFound | Should -Be $false
+        }
     }
     
     Context "Performance and Reliability" {


### PR DESCRIPTION
Hi,

I like to visualize the countries my server is accessed from. Since this plugin already does a lookup of the country it would be nice if the country could be set as a header in the response.

This PR adds on optional option `countryHeader` that will be populated with the resolved country.