### PR TITLE
🐛 fix(geoblock): let any selected hop deny, not just the first

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,9 @@ ipHeaders:
 | `CheckFirst` | Only the first IP |
 | `CheckFirstNonePrivate` | First public IP; if none, first private IP |
 
-Country allow/block uses the single `countryHeader` value (first public country written). `CheckAll` still applies CIDR and private rules to every selected IP. To choose which hop’s country is written, use `CheckFirst` / `CheckFirstNonePrivate`. To allow or deny a later hop by address, use CIDR lists or omit that hop from `ipHeaders`.
+Country allow/block uses the single `countryHeader` value (first public country written). `CheckAll` still applies CIDR and private rules to every selected IP. To choose which hop’s country is written, use `CheckFirst` / `CheckFirstNonePrivate`. To deny a later hop by address, use `blockedIPBlocks`, or omit that hop from `ipHeaders`.
+
+**Every selected hop can deny.** An earlier allowed hop does not vouch for the ones after it; `pass:{reason}` names the first *allowing* hop. If a forwarding proxy leaves its own private address in the chain, set `allowPrivate: true` or use `CheckFirstNonePrivate` — `allowedIPBlocks` cannot allow a private hop, because private and loopback addresses answer to `allowPrivate` before the CIDR lists are consulted.
 
 On lookup modes, `countryHeader` starts as `PRIVATE` and is overwritten by the first real country.
 

--- a/knowledge/devdocs/core_geoblock_plugin_request-mode.md
+++ b/knowledge/devdocs/core_geoblock_plugin_request-mode.md
@@ -49,4 +49,6 @@ if ModeBlocks(p.mode) && skipBlock == PhaseNone {
 
 - Chain enrich before block. Missing `countryHeader` uses `banIfError`.
 - Country rules use the one `countryHeader` value (first public written). `CheckAll` still applies CIDR and private per selected IP.
+- Every selected hop can deny: `blockFromHeader` returns on the first hop `decide` rejects. `passReason` names the first *allowing* phase for the `pass:{reason}` header and must not gate the deny.
+- `decide` answers private and loopback hops from `allowPrivate` **before** the CIDR lists, so `allowedIPBlocks` cannot allow a private hop.
 - `foldCountryHeader` copies `countryHeader` onto `requestHeaderEnrich` as `country` when that header name is unset.

--- a/openspec/changes/archive/2026-09-07-any-hop-can-deny/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-07-any-hop-can-deny/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-07

--- a/openspec/changes/archive/2026-09-07-any-hop-can-deny/design.md
+++ b/openspec/changes/archive/2026-09-07-any-hop-can-deny/design.md
@@ -1,0 +1,25 @@
+## Context
+
+See proposal.md — Why. `blockFromHeader` walks the hops selected by `ipHeaderStrategy` and calls `decide` per hop; the deny was gated on `passReason == PhaseNone`, which the first allowed hop set.
+
+## Goals / Non-Goals
+
+- A hop after the first can deny, as `core_geoblock_plugin_request-mode` already requires.
+- The `pass:{reason}` decision header keeps naming the first allowing phase.
+- No new configuration surface.
+- **Non-goal:** `decide` answers private and loopback hops from `allowPrivate` before consulting the CIDR lists, so `allowedIPBlocks` cannot allow a private hop. Pre-existing; documented in the README here, left for a separate change.
+
+## Decisions
+
+- **Delete the guard; do not restructure the loop.** Returning on the first deny is enough: deny is absorbing, so continuing would only change which phase is logged. Alternative: collect every hop's verdict then decide — rejected; behaviourally identical, costs lookups after the answer is known, and moves which hop the ban page names.
+- **No opt-out flag.** Alternative: a flag defaulting to today's behaviour — rejected; it would ship the bypass as the default indefinitely, and defaulting it to the new behaviour makes it a lever with no user. The remedy for the affected configuration is an existing option.
+- **`banIfError` in the loop is ungated too.** `ServeHTTP` already bans chain-wide on `lookupFailed && banIfError` in `enrichandblock`, so leaving the in-loop ban hop-0-gated would keep `block` mode disagreeing with `enrichandblock` on the same chain.
+
+## Risks / Trade-offs
+
+- The single `countryHeader` value is now applied to every selected hop, so a hop exempted by `allowedIPBlocks` no longer exempts the hops after it: `allowedIPBlocks: ["8.8.8.0/24"]` + `blockedCountries: ["US"]` on chain `8.8.8.8, 1.1.1.1` now denies at hop 1 under hop 0's `US` label. This follows the existing requirement that country allow/block use only the `countryHeader` value, and is pinned by a test rather than left to inference. A later hop's *own* country is still never evaluated; that is #66's design and is unchanged here.
+- `CreateConfig` sets `CheckAll` and leaves `allowPrivate` false, so a chain whose selected hops include a private address changes from pass to `403 block:allow_private`. Mitigation: `allowPrivate: true`, or `ipHeaderStrategy: CheckFirstNonePrivate`.
+
+## Migration Plan
+
+Ship. For chains of well-formed addresses, operators relying on an earlier allowed hop vouching for the chain reproduce the previous verdict with `ipHeaderStrategy: CheckFirst`; an `enrich` middleware on `CheckAll` chained to a `block` middleware on `CheckFirst` also reproduces the previous `countryHeader` value. Neither is exact for a chain containing an unparseable token, where `enrich` under `CheckAll` sets `lookupFailed` and `CheckFirst` does not. Rollback is a revert.

--- a/openspec/changes/archive/2026-09-07-any-hop-can-deny/proposal.md
+++ b/openspec/changes/archive/2026-09-07-any-hop-can-deny/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+`blockFromHeader` gates the deny on `passReason == PhaseNone` and sets `passReason` on the first **allowed** hop, so the first allowed hop discards every later denial. Under `ipHeaderStrategy: CheckAll`, `blockedIPBlocks` is then unenforceable on any hop but the first — with `blockedIPBlocks: ["1.1.1.0/24"]` and `defaultAllow: true`, `X-Forwarded-For: 1.1.1.1` is blocked but `8.8.8.8, 1.1.1.1` passes — and a country verdict is discarded whenever an earlier hop was allowed, typically a private one.
+
+That contradicts this capability's own requirement, "`CheckAll` SHALL still apply CIDR and private per selected IP", and the README sentence pointing operators at CIDR lists for per-hop control. It also makes `CheckAll` produce the same blocking decision as `CheckFirst` for any chain of well-formed addresses, since a later hop can only deny and the deny is gated shut once hop 0 is allowed.
+
+## What Changes
+
+- **BREAKING (behavior):** any selected hop may deny. The deny and the in-loop `banIfError` ban no longer require `passReason == PhaseNone`. `passReason` keeps one job: naming the first allowing phase for the `pass:{reason}` decision header.
+- No config change and no new option. For chains of well-formed addresses, `ipHeaderStrategy: CheckFirst` reproduces the previous verdict.
+- README documents the behaviour change, and that `allowedIPBlocks` cannot allow a private hop because `decide` answers private hops from `allowPrivate` first.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `core_geoblock_plugin_request-mode`: the block stage's per-hop guarantee is stated as enforceable — a hop after the first can deny — and `passReason` is confined to the pass log reason.
+
+## Impact
+
+- `pkg/geoblock/plugin.go` (`blockFromHeader`)
+- `pkg/geoblock/plugin_ipheaders_test.go` (`TestIPHeaderStrategy_CheckAllDeniesOnAnyHop`)
+- `README.md`, `knowledge/devdocs/core_geoblock_plugin_request-mode.md`
+- **Operators:** `CreateConfig` sets `CheckAll` and leaves `allowPrivate` false, so a chain whose selected hops include a private address changes from pass to `403 block:allow_private`. Remedy is `allowPrivate: true` or `ipHeaderStrategy: CheckFirstNonePrivate`.

--- a/openspec/changes/archive/2026-09-07-any-hop-can-deny/specs/core_geoblock_plugin_request-mode/spec.md
+++ b/openspec/changes/archive/2026-09-07-any-hop-can-deny/specs/core_geoblock_plugin_request-mode/spec.md
@@ -1,0 +1,34 @@
+## MODIFIED Requirements
+
+### Requirement: Block stage still applies CIDR and private
+When `mode` is `block` or `enrichandblock`, the plugin SHALL still extract IPs with `IPHeaders` / `ipHeaderStrategy` and SHALL apply `allowedIPBlocks`, `blockedIPBlocks`, and `allowPrivate`. A missing, empty, or `null` `countryHeader` value SHALL use `banIfError`. `PRIVATE` on `countryHeader` SHALL follow `allowPrivate`. Country allow/block SHALL use only the `countryHeader` value (first public written), not a later hop's looked-up country. `CheckAll` SHALL still apply CIDR and private per selected IP.
+
+Every selected hop SHALL be able to deny: an earlier allowed hop MUST NOT suppress a later hop's denial, nor a later hop's `banIfError` ban. The pass reason on the decision header SHALL be the phase of the first allowing hop.
+
+#### Scenario: Block CIDR without a database
+- **WHEN** `mode` is `block` and `blockedIPBlocks` contains `8.8.8.8/32`
+- **AND** the request IP is `8.8.8.8`
+- **THEN** the request is blocked
+- **AND** no catalog source was opened
+
+#### Scenario: Missing country header uses banIfError
+- **WHEN** `mode` is `block`, `banIfError` is true, and `countryHeader` is absent on the request
+- **THEN** the request is blocked
+
+#### Scenario: A blocked CIDR after an allowed hop still denies
+- **WHEN** `ipHeaderStrategy` is `CheckAll`, `defaultAllow` is true, and `blockedIPBlocks` contains `1.1.1.0/24`
+- **AND** the IP chain is `8.8.8.8, 1.1.1.1`
+- **THEN** the request is blocked
+- **AND** the decision header is `block:blocked_ip_block`
+
+#### Scenario: An allowedIPBlocks hop does not exempt the hops after it
+- **WHEN** `ipHeaderStrategy` is `CheckAll`, `allowedIPBlocks` contains `8.8.8.0/24`, `blockedCountries` contains `US`
+- **AND** the IP chain is `8.8.8.8, 1.1.1.1` and `countryHeader` resolved to `US`
+- **THEN** the request is blocked
+- **AND** the decision header is `block:blocked_country`
+
+#### Scenario: banIfError bans an unparseable later hop
+- **WHEN** `mode` is `block`, `banIfError` is true, `countryHeader` is present and allowed
+- **AND** the IP chain is `8.8.8.8, not-an-ip`
+- **THEN** the request is blocked
+- **AND** the decision header is `block:error`

--- a/openspec/changes/archive/2026-09-07-any-hop-can-deny/tasks.md
+++ b/openspec/changes/archive/2026-09-07-any-hop-can-deny/tasks.md
@@ -1,0 +1,15 @@
+## 1. Any hop can deny
+
+- [x] 1.1 Drop `passReason == PhaseNone` from the deny in `blockFromHeader`
+- [x] 1.2 Drop `passReason == PhaseNone` from the in-loop `banIfError` ban
+- [x] 1.3 Drop the unreachable `&& allowed` from the `passReason` assignment
+- [x] 1.4 Assert `blockedIPBlocks` denies the last hop and a middle hop after an allowed first hop
+- [x] 1.5 Assert `blockedCountries` denies a public hop behind an allowed private hop
+- [x] 1.6 Assert an `allowedIPBlocks` hop does not exempt the hops after it
+- [x] 1.7 Assert `banIfError` bans an unparseable later hop in `block` mode
+- [x] 1.8 Assert a chain no rule matches still passes `pass:default_allow`, and a private-only chain still passes `pass:allow_private`
+
+## 2. Docs
+
+- [x] 2.1 README: behaviour change, and that `allowedIPBlocks` cannot allow a private hop
+- [x] 2.2 Update `knowledge/devdocs/core_geoblock_plugin_request-mode.md`

--- a/openspec/specs/core_geoblock_plugin_request-mode/spec.md
+++ b/openspec/specs/core_geoblock_plugin_request-mode/spec.md
@@ -68,6 +68,8 @@ Plugin creation SHALL open enabled `databaseSources` rows only when `mode` is `e
 ### Requirement: Block stage still applies CIDR and private
 When `mode` is `block` or `enrichandblock`, the plugin SHALL still extract IPs with `IPHeaders` / `ipHeaderStrategy` and SHALL apply `allowedIPBlocks`, `blockedIPBlocks`, and `allowPrivate`. A missing, empty, or `null` `countryHeader` value SHALL use `banIfError`. `PRIVATE` on `countryHeader` SHALL follow `allowPrivate`. Country allow/block SHALL use only the `countryHeader` value (first public written), not a later hop's looked-up country. `CheckAll` SHALL still apply CIDR and private per selected IP.
 
+Every selected hop SHALL be able to deny: an earlier allowed hop MUST NOT suppress a later hop's denial, nor a later hop's `banIfError` ban. The pass reason on the decision header SHALL be the phase of the first allowing hop.
+
 #### Scenario: Block CIDR without a database
 - **WHEN** `mode` is `block` and `blockedIPBlocks` contains `8.8.8.8/32`
 - **AND** the request IP is `8.8.8.8`
@@ -77,6 +79,24 @@ When `mode` is `block` or `enrichandblock`, the plugin SHALL still extract IPs w
 #### Scenario: Missing country header uses banIfError
 - **WHEN** `mode` is `block`, `banIfError` is true, and `countryHeader` is absent on the request
 - **THEN** the request is blocked
+
+#### Scenario: A blocked CIDR after an allowed hop still denies
+- **WHEN** `ipHeaderStrategy` is `CheckAll`, `defaultAllow` is true, and `blockedIPBlocks` contains `1.1.1.0/24`
+- **AND** the IP chain is `8.8.8.8, 1.1.1.1`
+- **THEN** the request is blocked
+- **AND** the decision header is `block:blocked_ip_block`
+
+#### Scenario: An allowedIPBlocks hop does not exempt the hops after it
+- **WHEN** `ipHeaderStrategy` is `CheckAll`, `allowedIPBlocks` contains `8.8.8.0/24`, `blockedCountries` contains `US`
+- **AND** the IP chain is `8.8.8.8, 1.1.1.1` and `countryHeader` resolved to `US`
+- **THEN** the request is blocked
+- **AND** the decision header is `block:blocked_country`
+
+#### Scenario: banIfError bans an unparseable later hop
+- **WHEN** `mode` is `block`, `banIfError` is true, `countryHeader` is present and allowed
+- **AND** the IP chain is `8.8.8.8, not-an-ip`
+- **THEN** the request is blocked
+- **AND** the decision header is `block:error`
 
 ### Requirement: Block must not overwrite inbound enrich headers
 When `mode` is `block`, the plugin MUST NOT write `countryHeader` or `requestHeaderEnrich` values (`PRIVATE` / `null`) before reading the inbound country.

--- a/pkg/geoblock/plugin.go
+++ b/pkg/geoblock/plugin.go
@@ -412,6 +412,7 @@ func (p Plugin) blockFromHeader(rw http.ResponseWriter, req *http.Request, remot
 		}
 	}
 	var foundPublicIP bool
+	// passReason is only the pass log reason; any selected hop may deny.
 	passReason := PhaseNone
 	for i, ip := range remoteIPs {
 		if p.skipIP(i, ip, remoteIPs, &foundPublicIP) {
@@ -420,19 +421,19 @@ func (p Plugin) blockFromHeader(rw http.ResponseWriter, req *http.Request, remot
 		allowed, phase, err := p.decide(ip, country)
 		if err != nil {
 			p.logLookupError(req, ip, ipChain, remoteIPs, err)
-			if p.banIfError && passReason == PhaseNone {
+			if p.banIfError {
 				p.setDecisionLogHeader(req, LogStatusBlock, "error")
 				p.serveBanHtml(rw, ip, "Unknown", req.Method)
 				return true
 			}
 			continue
 		}
-		if !allowed && passReason == PhaseNone {
+		if !allowed {
 			p.setDecisionLogHeader(req, LogStatusBlock, phase)
 			p.serveBanHtml(rw, ip, countryForBan(ip, country), req.Method)
 			return true
 		}
-		if passReason == PhaseNone && allowed {
+		if passReason == PhaseNone {
 			passReason = phase
 		}
 		if p.ipHeaderStrategy == IPHeaderStrategyCheckFirstNonePrivate && !privateOrLoopback(ip) {

--- a/pkg/geoblock/plugin_ipheaders_test.go
+++ b/pkg/geoblock/plugin_ipheaders_test.go
@@ -808,3 +808,134 @@ func TestRemoteAddress_IntegrationWithStrategies(t *testing.T) {
 		})
 	}
 }
+
+// TestIPHeaderStrategy_CheckAllDeniesOnAnyHop pins the CheckAll contract: every
+// selected hop is subject to the CIDR and private rules, so a hop after the first
+// can deny even when an earlier hop was allowed.
+func TestIPHeaderStrategy_CheckAllDeniesOnAnyHop(t *testing.T) {
+	tests := []struct {
+		name              string
+		configure         func(*Config)
+		requestHeaders    map[string]string
+		headerValue       string
+		expectedStatus    int
+		expectedLogDetail string
+	}{
+		{
+			name: "blockedIPBlocks denies the last hop after an allowed first hop",
+			configure: func(c *Config) {
+				c.DefaultAllow = true
+				c.BlockedIPBlocks = []string{"1.1.1.0/24"}
+			},
+			headerValue:       "8.8.8.8, 1.1.1.1",
+			expectedStatus:    http.StatusForbidden,
+			expectedLogDetail: LogStatusBlock + ":" + PhaseBlockedIPBlock,
+		},
+		{
+			name: "blockedIPBlocks denies a middle hop",
+			configure: func(c *Config) {
+				c.DefaultAllow = true
+				c.BlockedIPBlocks = []string{"1.1.1.0/24"}
+			},
+			headerValue:       "8.8.8.8, 1.1.1.1, 9.9.9.9",
+			expectedStatus:    http.StatusForbidden,
+			expectedLogDetail: LogStatusBlock + ":" + PhaseBlockedIPBlock,
+		},
+		{
+			name: "a blocked country is denied behind an allowed private hop",
+			configure: func(c *Config) {
+				c.DefaultAllow = false
+				c.AllowPrivate = true
+				c.BlockedCountries = []string{"US"}
+			},
+			headerValue:       "10.0.0.1, 8.8.8.8",
+			expectedStatus:    http.StatusForbidden,
+			expectedLogDetail: LogStatusBlock + ":" + PhaseBlockedCountry,
+		},
+		{
+			// allowedIPBlocks exempts the hop it matches, not the chain. The
+			// countryHeader value is the first public country written, so a later
+			// hop is judged against that country, not its own.
+			name: "an allowedIPBlocks hop does not exempt the hops after it",
+			configure: func(c *Config) {
+				c.DefaultAllow = true
+				c.AllowedIPBlocks = []string{"8.8.8.0/24"}
+				c.BlockedCountries = []string{"US"}
+			},
+			headerValue:       "8.8.8.8, 1.1.1.1",
+			expectedStatus:    http.StatusForbidden,
+			expectedLogDetail: LogStatusBlock + ":" + PhaseBlockedCountry,
+		},
+		{
+			// block mode has no enrich stage, so the inbound country is used as is
+			// and an unparseable later hop reaches decide. enrichandblock already
+			// banned this chain-wide from ServeHTTP.
+			name: "banIfError bans an unparseable later hop in block mode",
+			configure: func(c *Config) {
+				c.Mode = ModeBlock
+				c.BanIfError = true
+				c.DefaultAllow = true
+			},
+			requestHeaders:    map[string]string{"x-country-code": "DE"},
+			headerValue:       "8.8.8.8, not-an-ip",
+			expectedStatus:    http.StatusForbidden,
+			expectedLogDetail: LogStatusBlock + ":error",
+		},
+		{
+			name: "a chain no rule matches still passes",
+			configure: func(c *Config) {
+				c.DefaultAllow = true
+				c.BlockedIPBlocks = []string{"1.1.1.0/24"}
+			},
+			headerValue:       "8.8.8.8, 9.9.9.9",
+			expectedStatus:    http.StatusTeapot,
+			expectedLogDetail: LogStatusPass + ":" + PhaseDefaultAllow,
+		},
+		{
+			name: "a private-only chain still passes on allowPrivate",
+			configure: func(c *Config) {
+				c.DefaultAllow = false
+				c.AllowPrivate = true
+			},
+			headerValue:       "10.0.0.1, 10.0.0.2",
+			expectedStatus:    http.StatusTeapot,
+			expectedLogDetail: LogStatusPass + ":" + PhaseAllowPrivate,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{
+				Mode:                  ModeEnrichAndBlock,
+				DatabaseSources:       seedCatalog(dbFilePath),
+				DisallowedStatusCode:  http.StatusForbidden,
+				IPHeaders:             []string{"x-forwarded-for"},
+				IPHeaderStrategy:      IPHeaderStrategyCheckAll,
+				CountryHeader:         "x-country-code",
+				LogStatusDetailHeader: "X-Geoblock-Decision",
+			}
+			tt.configure(cfg)
+
+			plugin, err := newRoute(holdCtx(t), &noopHandler{}, cfg, pluginName)
+			if err != nil {
+				t.Fatalf("Failed to create plugin: %v", err)
+			}
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			req.Header.Set("X-Forwarded-For", tt.headerValue)
+			for name, value := range tt.requestHeaders {
+				req.Header.Set(name, value)
+			}
+
+			rr := httptest.NewRecorder()
+			plugin.ServeHTTP(rr, req)
+
+			if rr.Code != tt.expectedStatus {
+				t.Errorf("X-Forwarded-For %q: status %d, want %d", tt.headerValue, rr.Code, tt.expectedStatus)
+			}
+			if got := req.Header.Get("X-Geoblock-Decision"); got != tt.expectedLogDetail {
+				t.Errorf("X-Forwarded-For %q: decision %q, want %q", tt.headerValue, got, tt.expectedLogDetail)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why

Under `CheckAll`, a hop after the first cannot deny: the first **allowed** hop sets `passReason`, and the deny in `blockFromHeader` is gated on `passReason == PhaseNone`. So unless hop 0 itself errors, `blockedIPBlocks` and the country rules only ever apply to hop 0.

The gate looks like a leftover. `cea5b78` (#47) replaced the bypass flag `skipBlocking` with `passReason` and also set it inside the hop loop, "only if no bypass is active". #66 then moved the bypass conditions out into `blockSkipReason` with an early return — so inside `blockFromHeader` the guard can no longer represent a bypass, and only ever fires on an earlier allowed hop. Present since v1.1.4.

That leaves the documented behaviour unmet:

- `openspec/specs/core_geoblock_plugin_request-mode/spec.md`: "`CheckAll` SHALL still apply CIDR and private per selected IP."
- `README.md`: "To allow or deny a later hop by address, use CIDR lists or omit that hop from `ipHeaders`."

And it makes `CheckAll` produce the same blocking decision as `CheckFirst` for any chain of well-formed addresses. Measured on `master`, 11 chains × both `banIfError` settings: identical verdicts except where a hop is an unparseable token; only the enriched country differs.

No existing test covers it — the `pkg/geoblock` suite passes with the gate removed.

## Reproducing it

Fastest check, no stack needed: revert `pkg/geoblock/plugin.go` to `master`, keep the new test, and `go test ./pkg/geoblock/ -run CheckAllDeniesOnAnyHop` — five deny cases fail, both pass cases hold.

End to end: the committed `docker-compose.yml`, unmodified (the `v1.2.0` column is the same stack brought up on `master`). `geoblock2@docker` on `/foo` is `allowPrivate: true`, `blockedCountries: US,CN,RU`, `allowedCountries: DE,FR,GB`, `defaultAllow: false` on the bundled IP2Location LITE seed. `docker compose up -d`, then `curl -H "X-Forwarded-For: …" localhost:8000/foo` (the prepended hop is client-supplied; the compose sets `forwardedHeaders.insecure=true`):

| `X-Forwarded-For` | v1.2.0 | this PR |
| --- | --- | --- |
| `8.8.8.8` (US) | 403 | 403 |
| `10.0.0.1, 8.8.8.8` | **200** | 403 |
| `127.0.0.1, 8.8.8.8` | **200** | 403 |
| `8.8.8.8, 10.0.0.1` | 403 | 403 |
| `10.0.0.1` | 200 | 200 |

Allowed-country clients behind a private hop are unaffected: `10.0.0.1, 217.160.0.1` → 200 `X-Ipcountry: DE`, `127.0.0.1, 212.58.224.1` → 200 `GB`.

## What changed

Two gate clauses removed (plus a dead `&& allowed`), so the deny and the in-loop `banIfError` ban no longer consult `passReason`. It keeps one job: naming the first allowing phase for the `pass:{reason}` header. No restructuring, no new config.

## What this changes for consumers

Removing the gates can only turn passes into denies, never the reverse. Measured at unit level on `master` ± this diff, `defaultAllow: true`:

| config | chain | v1.2.0 | this PR |
| --- | --- | --- | --- |
| `allowPrivate` unset | `8.8.8.8, 10.0.0.5` | pass | **403 `block:allow_private`** |
| + `allowedIPBlocks: ["10.0.0.5/32"]` | `8.8.8.8, 10.0.0.5` | pass | **403 `block:allow_private`** |
| `allowedIPBlocks: ["8.8.8.0/24"]`, `blockedCountries: ["US"]` | `8.8.8.8, 1.1.1.1` | pass | **403 `block:blocked_country`** |
| `mode: block`, `banIfError: true` (the default), inbound country header allowed | `8.8.8.8, not-an-ip` | pass | **403 `block:error`** |

Row 1 is the one most likely to bite: `CreateConfig` sets `CheckAll` and leaves `allowPrivate` at `false`, so a chain whose **selected** hops include a private address now denies. Either existing option restores it — measured on this branch, same chain: `allowPrivate: true` → pass, `CheckFirstNonePrivate` → pass.

Row 2: `decide` answers private and loopback hops from `allowPrivate` before the CIDR lists, so `allowedIPBlocks` cannot allow a private hop. Pre-existing, newly reachable. I added a README line for it — happy to drop that if you would rather change the ordering.

Row 3 is the judgement call. An allowlisted `8.8.8.8` client behind a public proxy at `1.1.1.1` now gets 403, because the proxy hop is judged under the client's `US` label. That follows the existing requirement that country allow/block use only the `countryHeader` value, and is pinned by a test. A later hop's *own* country is still never evaluated — #66's design, unchanged here. If you would rather it be evaluated once per request, that is a change to how the country is resolved; happy to open that separately.

Row 4: only `mode: block` with an inbound `countryHeader` changes. `enrichandblock` already banned chain-wide from `ServeHTTP` on `lookupFailed && banIfError`, and without that header the top of `blockFromHeader` already banned.

## Verification

`go test ./...` passes on this branch except `pkg/reclaim`'s timing tests, which fail the same way on unmodified `master` on this machine. `golangci-lint run ./...` is clean. `vendor/` untouched.

The Pester integration suite passes against the committed compose: **65 passed, 0 failed, 4 skipped** — byte-identical to pristine `master` run the same way on a clean stack. The 4 skips are the token-gated download tests.
