### PR TITLE
🐛 fix(geoblock): never put an IP header value on countryHeader

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,7 +420,7 @@ Country allow/block uses the single `countryHeader` value (first public country 
 
 **Every selected hop can deny.** An earlier allowed hop does not vouch for the ones after it; `pass:{reason}` names the first *allowing* hop. If a forwarding proxy leaves its own private address in the chain, set `allowPrivate: true` or use `CheckFirstNonePrivate` — `allowedIPBlocks` cannot allow a private hop, because private and loopback addresses answer to `allowPrivate` before the CIDR lists are consulted.
 
-On lookup modes, `countryHeader` starts as `PRIVATE` and is overwritten by the first real country. A public IP for which no enabled source returns a country is `XX`, so it reaches the country rules and `defaultAllow` rather than `allowPrivate`. `XX` is ISO 3166-1 user-assigned and may be listed in `allowedCountries` / `blockedCountries`. An IP2Location `bin` miss (`country_short` `-`) is empty at merge, so a later catalog source may fill country and a BIN-only miss still writes `XX`.
+On lookup modes, `countryHeader` starts as `PRIVATE` and is overwritten by the first real country. An IP header value the plugin cannot parse enriches as `XX`, never as itself — the header only ever carries an ISO country, `PRIVATE` or `XX`. A public IP for which no enabled source returns a country is `XX`, so it reaches the country rules and `defaultAllow` rather than `allowPrivate`. `XX` is ISO 3166-1 user-assigned and may be listed in `allowedCountries` / `blockedCountries`. An IP2Location `bin` miss (`country_short` `-`) is empty at merge, so a later catalog source may fill country and a BIN-only miss still writes `XX`.
 
 ### Path include / exclude
 

--- a/knowledge/devdocs/core_geoblock_plugin_request-mode.md
+++ b/knowledge/devdocs/core_geoblock_plugin_request-mode.md
@@ -52,4 +52,5 @@ if ModeBlocks(p.mode) && skipBlock == PhaseNone {
 - Country rules use the one `countryHeader` value (first public written). `CheckAll` still applies CIDR and private per selected IP.
 - Every selected hop can deny: `blockFromHeader` returns on the first hop `decide` rejects. `passReason` names the first *allowing* phase for the `pass:{reason}` header and must not gate the deny.
 - `decide` answers private and loopback hops from `allowPrivate` **before** the CIDR lists, so `allowedIPBlocks` cannot allow a private hop.
+- `enrich` writes the lookup record to the enrich headers **before** it checks the returned error, so `recordForLookup` returns no country on its error paths. `writePublicLookupHeaders` maps an empty country to `XX` without marking it written.
 - `foldCountryHeader` copies `countryHeader` onto `requestHeaderEnrich` as `country` when that header name is unset.

--- a/openspec/changes/archive/2026-09-07-no-token-as-country/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-07-no-token-as-country/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-07

--- a/openspec/changes/archive/2026-09-07-no-token-as-country/design.md
+++ b/openspec/changes/archive/2026-09-07-no-token-as-country/design.md
@@ -1,0 +1,26 @@
+## Context
+
+See proposal.md — Why. `enrich` calls `writePublicLookupHeaders(req, rec, &written)` and only then checks the error `recordForLookup` returned, so anything in `rec.Country` is already on the header.
+
+## Goals / Non-Goals
+
+- `countryHeader` only ever carries the values the spec enumerates.
+- `banIfError` behaviour is unchanged.
+- **Non-goal:** reordering `enrich` so headers are written after the error check. That would leave the `PRIVATE` default in place for a failed hop, which is the fail-open #76 fixed.
+
+## Decisions
+
+- **Drop the country from the error records rather than reorder the caller.** Alternative: move the write below the `if err != nil` — rejected and measured. It leaves the `PRIVATE` default on the failed hop, so `mode: enrich` with `X-Forwarded-For: Norway` enriches as `PRIVATE`, a legal value meaning "internal address"; under `defaultAllow: false` the block stage then reads it as the `allowPrivate` verdict. That is #76's fail-open again. Letting the empty country fall into the existing `XX` branch avoids it. Letting the empty country fall into the existing `XX` branch reuses the mechanism #76 added and needs no new state.
+- **`XX`, not a new sentinel.** An unparseable hop is a hop with no known country, which is what `XX` already means. It does not mark the country written, so a later resolving hop still wins — `DE, 8.8.8.8` ends `US`.
+- **Empty country, not `XX` written directly in `recordForLookup`.** Returning `Record{Country: XX}` would take the normal write path and mark the country written, locking the header so a later resolving hop could not win — the alternative #76's own design rejected.
+- **Both error paths, not just the unparseable one.** The `Lookup` error return has the same shape and the same caller. Its value must parse as an IP so it is not free-form, but an address is still not an ISO country.
+
+## Risks / Trade-offs
+
+- `countryHeader` changes value for unparseable hops, from the token to `XX`. Anything downstream keying on the token breaks — but it was keying on client-controlled input.
+- With `defaultAllow: false` and `banIfError: false`, a chain whose first hop is a token naming an allowed country stops passing. That is the defect, not a regression.
+- A chain whose hops all fail to parse still passes under `banIfError: false` (`Norway` alone is `pass:none`, before and after). Nothing denied, and that setting makes errors non-fatal. Out of scope here.
+
+## Migration Plan
+
+Ship. No config change. Operators who want the old permissiveness for failed lookups already have `banIfError: false` plus `allowedCountries: [XX]`.

--- a/openspec/changes/archive/2026-09-07-no-token-as-country/proposal.md
+++ b/openspec/changes/archive/2026-09-07-no-token-as-country/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+`recordForLookup` returns `dbprovider.Record{Country: ip}` on both of its error paths, and `enrich` writes that record to the country enrich headers **before** it checks the returned error. The IP header value is caller-controlled, so `countryHeader` becomes whatever the client sent.
+
+In `mode: enrich` with every setting at its default, `X-Forwarded-For: Norway` reaches the backend as `X-IPCountry: Norway`. The header is the plugin's product in that mode, and any client that can set an IP header sets it.
+
+This contradicts `core_geoblock_plugin_request-mode`, which enumerates what lookup may write there: "the ISO country, `PRIVATE` for a private or loopback hop, or `XX` for a public hop the enabled sources returned no country for". A raw token is none of those. `decide`'s own parse-failure path already returns no country, and `pkg/geoblock/plugin_policy_test.go` already asserts that a provider lookup of a bad address yields an **empty** country — `recordForLookup` overrides that one layer up.
+
+The value was unobservable when it was written: at the initial import there was no `countryHeader`, and the caller checked the error and discarded the record. PR #11 added the header write before the error check, and #66 made the block stage read the header back as the country.
+
+## What Changes
+
+- Both error returns in `recordForLookup` carry no country. `writePublicLookupHeaders` already maps an empty country to `XX` without marking the country written, so an unresolvable hop is `XX` like any other and a later hop that does resolve still wins.
+- No config change, no new option. `banIfError` still fires: the error is returned unchanged, so `lookupFailed` and the in-loop ban are untouched.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `core_geoblock_plugin_request-mode`: the countryHeader value set is stated as exhaustive — an IP header value the plugin cannot parse, or an address whose lookup errors, never reaches the header.
+
+## Impact
+
+- `pkg/geoblock/plugin.go` (`recordForLookup`)
+- `pkg/geoblock/plugin_mode_test.go`
+- `README.md`, `knowledge/devdocs/core_geoblock_plugin_request-mode.md`
+- `geoblockban.html` `data-country="{{.Country}}"` via `serveBanHtml`, which interpolates without escaping: the token reached the ban page body and could leave the attribute. Same-sender only, so not cross-user. The escaping itself is out of scope — `mode: block` must pass an inbound `X-IPCountry` through unchanged.
+- **Operators:** `countryHeader` changes from the raw token to `XX` for an unparseable hop. Anything downstream that matched on the token stops matching. With `defaultAllow: false` and `banIfError: false`, a chain led by a token that happened to name an allowed country stops passing — it was passing on a client-supplied value.

--- a/openspec/changes/archive/2026-09-07-no-token-as-country/specs/core_geoblock_plugin_request-mode/spec.md
+++ b/openspec/changes/archive/2026-09-07-no-token-as-country/specs/core_geoblock_plugin_request-mode/spec.md
@@ -1,0 +1,13 @@
+## MODIFIED Requirements
+
+### Requirement: Country header is the write/read bridge
+When `mode` is not `disabled`, `countryHeader` SHALL be a request header name. Empty `countryHeader` SHALL default to `X-IPCountry`. Lookup (`enrich` or `enrichandblock`) SHALL write the ISO country, `PRIVATE` for a private or loopback hop, or `XX` for a public hop the enabled sources returned no country for, to that header. **Those values are exhaustive: an IP header value the plugin cannot parse, and an address whose lookup returns an error, SHALL NOT reach that header, and SHALL enrich as `XX`.** A BIN source that answers IP2Location `-` for `country_short` SHALL count as no country after merge. `XX` SHALL NOT mark the country written, so a later hop that resolves still wins. The block stage (`block` or `enrichandblock`) SHALL read that same header for country allow/block. Country rules MUST NOT take the lookup `Record` country directly. A `requestHeaderEnrich` mapping whose key is `country` and whose header name is not `countryHeader` SHALL also be written. Plugin creation MUST NOT fail because more than one header maps to `country`. When a request is handled by a `mode` `enrich` hop and then a `mode` `block` hop that share the same `countryHeader`, the block hop SHALL allow or deny using the country the enrich hop wrote.
+
+#### Scenario: An unparseable IP header value is not a country
+- **WHEN** `mode` is `enrich` and `X-Forwarded-For` is `Norway`
+- **THEN** `countryHeader` is `XX`
+
+#### Scenario: A later hop that resolves wins over an unparseable one
+- **WHEN** `mode` is `enrich` and `X-Forwarded-For` is `DE, 8.8.8.8`
+- **AND** `8.8.8.8` looks up as `US`
+- **THEN** `countryHeader` is `US`

--- a/openspec/changes/archive/2026-09-07-no-token-as-country/tasks.md
+++ b/openspec/changes/archive/2026-09-07-no-token-as-country/tasks.md
@@ -1,0 +1,12 @@
+## 1. No token as country
+
+- [x] 1.1 Return a record with no country from both `recordForLookup` error paths
+- [x] 1.2 Assert an unparseable IP header value yields `XX`, not the token
+- [x] 1.3 Assert a later hop that resolves still wins over an unparseable earlier hop
+- [x] 1.4 Assert a resolvable hop and a private hop are unaffected
+- [x] 1.5 Assert a lookup error carries no country
+
+## 2. Docs
+
+- [x] 2.1 README: an unparseable IP header value enriches as `XX`
+- [x] 2.2 Update `knowledge/devdocs/core_geoblock_plugin_request-mode.md`

--- a/openspec/specs/core_geoblock_plugin_request-mode/spec.md
+++ b/openspec/specs/core_geoblock_plugin_request-mode/spec.md
@@ -21,7 +21,16 @@ Traefik Config SHALL expose `mode` as `disabled`, `enrich`, `block`, or `enricha
 - **THEN** that field is not part of Config (Yaegi does not decode it onto the plugin)
 
 ### Requirement: Country header is the write/read bridge
-When `mode` is not `disabled`, `countryHeader` SHALL be a request header name. Empty `countryHeader` SHALL default to `X-IPCountry`. Lookup (`enrich` or `enrichandblock`) SHALL write the ISO country, `PRIVATE` for a private or loopback hop, or `XX` for a public hop the enabled sources returned no country for, to that header. A BIN source that answers IP2Location `-` for `country_short` SHALL count as no country after merge. `XX` SHALL NOT mark the country written, so a later hop that resolves still wins. The block stage (`block` or `enrichandblock`) SHALL read that same header for country allow/block. Country rules MUST NOT take the lookup `Record` country directly. A `requestHeaderEnrich` mapping whose key is `country` and whose header name is not `countryHeader` SHALL also be written. Plugin creation MUST NOT fail because more than one header maps to `country`. When a request is handled by a `mode` `enrich` hop and then a `mode` `block` hop that share the same `countryHeader`, the block hop SHALL allow or deny using the country the enrich hop wrote.
+When `mode` is not `disabled`, `countryHeader` SHALL be a request header name. Empty `countryHeader` SHALL default to `X-IPCountry`. Lookup (`enrich` or `enrichandblock`) SHALL write the ISO country, `PRIVATE` for a private or loopback hop, or `XX` for a public hop the enabled sources returned no country for, to that header. Those values are exhaustive: an IP header value the plugin cannot parse, and an address whose lookup returns an error, SHALL NOT reach that header, and SHALL enrich as `XX`. A BIN source that answers IP2Location `-` for `country_short` SHALL count as no country after merge. `XX` SHALL NOT mark the country written, so a later hop that resolves still wins. The block stage (`block` or `enrichandblock`) SHALL read that same header for country allow/block. Country rules MUST NOT take the lookup `Record` country directly. A `requestHeaderEnrich` mapping whose key is `country` and whose header name is not `countryHeader` SHALL also be written. Plugin creation MUST NOT fail because more than one header maps to `country`. When a request is handled by a `mode` `enrich` hop and then a `mode` `block` hop that share the same `countryHeader`, the block hop SHALL allow or deny using the country the enrich hop wrote.
+
+#### Scenario: An unparseable IP header value is not a country
+- **WHEN** `mode` is `enrich` and `X-Forwarded-For` is `Norway`
+- **THEN** `countryHeader` is `XX`
+
+#### Scenario: A later hop that resolves wins over an unparseable one
+- **WHEN** `mode` is `enrich` and `X-Forwarded-For` is `DE, 8.8.8.8`
+- **AND** `8.8.8.8` looks up as `US`
+- **THEN** `countryHeader` is `US`
 
 #### Scenario: Enrich writes countryHeader
 - **WHEN** `mode` is `enrich` and `countryHeader` is `X-IPCountry`

--- a/pkg/geoblock/plugin.go
+++ b/pkg/geoblock/plugin.go
@@ -486,17 +486,18 @@ func (p Plugin) CheckAllowed(ip string) (allow bool, phase string, err error) {
 }
 
 // recordForLookup is PRIVATE for private/loopback IPs, else catalog Lookup.
+// Errors carry no country: enrich writes this record before it checks err, and ip is client-set.
 func (p Plugin) recordForLookup(ip string) (dbprovider.Record, error) {
 	ipAddr := net.ParseIP(ip)
 	if ipAddr == nil {
-		return dbprovider.Record{Country: ip}, fmt.Errorf("unable to parse IP address from [%s]", ip)
+		return dbprovider.Record{}, fmt.Errorf("unable to parse IP address from [%s]", ip)
 	}
 	if ipAddr.IsPrivate() || ipAddr.IsLoopback() {
 		return dbprovider.Record{Country: PrivateIpCountryAlias}, nil
 	}
 	rec, err := p.Lookup(ip)
 	if err != nil {
-		return dbprovider.Record{Country: ip}, fmt.Errorf("lookup of %s failed: %w", ip, err)
+		return dbprovider.Record{}, fmt.Errorf("lookup of %s failed: %w", ip, err)
 	}
 	return rec, nil
 }

--- a/pkg/geoblock/plugin_mode_test.go
+++ b/pkg/geoblock/plugin_mode_test.go
@@ -581,3 +581,88 @@ func TestMode_UnresolvedPublicIPFollowsDefaultAllow(t *testing.T) {
 		}
 	})
 }
+
+// TestMode_UnparseableHopDoesNotBecomeCountry pins that an IP header value the
+// plugin cannot parse never reaches countryHeader. Only the ISO country, PRIVATE
+// and XX are legal there, so an unresolvable hop is XX like any other, and a
+// later hop that does resolve still wins.
+func TestMode_UnparseableHopDoesNotBecomeCountry(t *testing.T) {
+	tests := []struct {
+		name            string
+		mode            string
+		headerValue     string
+		expectedCountry string
+	}{
+		{
+			name:            "a country code in the IP header is not a country",
+			mode:            ModeEnrich,
+			headerValue:     "DE",
+			expectedCountry: UnknownCountryAlias,
+		},
+		{
+			name:            "arbitrary text in the IP header is not a country",
+			mode:            ModeEnrich,
+			headerValue:     "Norway",
+			expectedCountry: UnknownCountryAlias,
+		},
+		{
+			name:            "a later hop wins over an unparseable one",
+			mode:            ModeEnrich,
+			headerValue:     "DE, 8.8.8.8",
+			expectedCountry: "US",
+		},
+		{
+			name:            "enrichandblock behaves the same",
+			mode:            ModeEnrichAndBlock,
+			headerValue:     "DE, 8.8.8.8",
+			expectedCountry: "US",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{
+				Mode:                 tt.mode,
+				DatabaseSources:      seedCatalog(dbFilePath),
+				DefaultAllow:         true,
+				AllowPrivate:         true,
+				BanIfError:           false,
+				DisallowedStatusCode: http.StatusForbidden,
+				IPHeaders:            []string{"x-forwarded-for"},
+				IPHeaderStrategy:     IPHeaderStrategyCheckAll,
+				CountryHeader:        "X-IPCountry",
+			}
+
+			plugin, err := newRoute(holdCtx(t), &noopHandler{}, cfg, pluginName)
+			if err != nil {
+				t.Fatalf("Failed to create plugin: %v", err)
+			}
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			req.Header.Set("X-Forwarded-For", tt.headerValue)
+
+			rr := httptest.NewRecorder()
+			plugin.ServeHTTP(rr, req)
+
+			if got := req.Header.Get("X-IPCountry"); got != tt.expectedCountry {
+				t.Errorf("X-Forwarded-For %q: X-IPCountry %q, want %q", tt.headerValue, got, tt.expectedCountry)
+			}
+		})
+	}
+}
+
+// TestMode_LookupErrorCarriesNoCountry pins the second error path: a parseable
+// address whose lookup fails must not put the address itself on countryHeader.
+func TestMode_LookupErrorCarriesNoCountry(t *testing.T) {
+	p := Plugin{db: dbprovider.Bind(func(ip string) (dbprovider.Record, error) {
+		return dbprovider.Record{}, fmt.Errorf("source unavailable")
+	})}
+
+	rec, err := p.recordForLookup("8.8.8.8")
+	if err == nil {
+		t.Fatal("expected a lookup error")
+	}
+	if rec.Country != "" {
+		t.Errorf("country %q, want empty: the record is written to countryHeader before err is checked", rec.Country)
+	}
+}


### PR DESCRIPTION
## Why

In `mode: enrich` with every setting at its default, the client chooses what the backend receives as the country:

| client sends `X-Forwarded-For` | backend receives `X-IPCountry` |
| --- | --- |
| `8.8.8.8` | `US` |
| `10.0.0.1` | `PRIVATE` |
| `Norway` | **`Norway`** |
| `DE` | **`DE`** |

`recordForLookup` returns `dbprovider.Record{Country: ip}` on both error paths (`plugin.go:492`, `:499`), and `enrich` passes that record to `writePublicLookupHeaders` **before** it checks the error. The value is client-supplied wherever the entrypoint accepts forwarded headers — as the committed `docker-compose.yml` does with `forwardedHeaders.insecure=true` — so it lands on `countryHeader` verbatim. Enrichment is the plugin's whole output in `enrich` mode.

Three places in the tree already assume this cannot happen:

- `openspec/specs/core_geoblock_plugin_request-mode/spec.md:24`: lookup "SHALL write the ISO country, `PRIVATE` for a private or loopback hop, or `XX` for a public hop the enabled sources returned no country for". A raw token is none of those.
- `decide`'s own parse-failure path returns `false, "", err` — no country (`plugin.go:508`). The #66 refactor that created `recordForLookup` dropped the token there but kept it here.
- `pkg/geoblock/plugin_policy_test.go:433` already asserts a provider lookup of `"foobar"` yields an **empty** country. `recordForLookup` overrides that one layer up.

It was unobservable when written — the initial import had no `countryHeader`, and the caller checked the error and discarded the record. PR #11 added the header write before the error check; #66 made the block stage read that header back as the country. #76's proposal describes the same path for `PRIVATE`: "nothing reconciled it with the header becoming a policy input."

## What changed

Both error returns carry no country. `writePublicLookupHeaders` already maps an empty country to `XX` **without** marking the country written, so an unresolvable hop is `XX` like any other and a later hop that does resolve still wins — `DE, 8.8.8.8` ends `US`. The returned error is unchanged, so `lookupFailed` and `banIfError` behave exactly as before.

I did not move the header write below the error check instead: that would leave the `PRIVATE` default on a failed hop, which is the fail-open #76 fixed.

## What this changes for consumers

`countryHeader` for an unparseable hop goes from the raw token to `XX`. Anything downstream keying on the token stops matching — it was keying on client-supplied input.

The ban page is one such consumer: `serveBanHtml` interpolates with `strings.ReplaceAll` and no escaping into `data-country="{{.Country}}" data-ip="{{.IP}}"` (`geoblockban.html:80`). With `X-Forwarded-For: "><b>pwned</b, 8.8.8.8`, `data-country` renders `""><b>pwned</b"` on `master` and `"US"` here.

**That closes only one of the two sinks.** `{{.IP}}` takes the same unescaped path and is unchanged here — with `banIfError: true` the page still renders `data-ip=""><b>pwned</b"` on `master` and on this branch, because `serveBanHtml` gets the raw hop. Escaping `serveBanHtml` is a separate question, as is the inbound `X-IPCountry` that `mode: block` must pass through; happy to open either. Both are same-sender only, not cross-user.

One blocking case changes, and it needs the non-default `banIfError: false`. With `defaultAllow: false`, `allowedCountries: [GB,DE]`, `blockedCountries: [US]`, `CheckAll`, chain `DE, 8.8.8.8` returns **`pass:allowed_country`** on `master`, where `8.8.8.8` alone is `403 block:blocked_country`; with this change it blocks. A chain whose hops **all** fail to parse still passes under `banIfError: false` — `Norway` alone is `pass:none` before and after — unchanged here.

Under the default `banIfError: true` the `DE, 8.8.8.8` chain was already blocked (`block:error`) both in one middleware and in the `enrich`→`block` split — in the split it is `decide`'s `net.ParseIP` that fires, not `lookupFailed` — but the header was poisoned either way, and `mode: enrich` never blocks at all.

## Verification

To reproduce: revert `pkg/geoblock/plugin.go` to `master`, keep the new tests, and

    go test ./pkg/geoblock/ -run 'TestMode_UnparseableHopDoesNotBecomeCountry|TestMode_LookupErrorCarriesNoCountry'

All four subtests and the unit test fail; they pass with the diff applied.

`TestMode_UnparseableHopDoesNotBecomeCountry` was watched failing on `master` first: `DE`, `Norway` and `DE, 8.8.8.8` returned the token; the resolvable-hop and private-hop controls held. `TestMode_LookupErrorCarriesNoCountry` covers the second error path with a stubbed provider via the existing `dbprovider.Bind`. Both returns were mutation-checked — restoring either fails a test.

`golangci-lint run ./...` clean. `vendor/` untouched. `go test ./...` passes except `pkg/reclaim`'s grace-timing test, which is load-dependent here — in one clean-stack pair it failed on `master` and passed on this branch. Pester integration suite on a clean stack: 65 passed, 0 failed, 4 skipped (token-gated downloads).
